### PR TITLE
fix: ensure data files are available during CI build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,11 @@ jobs:
           cache: npm
           cache-dependency-path: site/package-lock.json
 
+      - name: Copy data into site public directory
+        run: |
+          mkdir -p site/public/data
+          cp data/*.json site/public/data/ 2>/dev/null || true
+
       - name: Install dependencies
         working-directory: site
         run: npm ci || npm install

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -22,22 +22,31 @@ interface IndicatorData {
 }
 
 function loadIndicators(): IndicatorData[] {
-  const dataDir = path.join(process.cwd(), "..", "data");
-  if (!fs.existsSync(dataDir)) return [];
+  // Try multiple paths: ../data (repo root) and public/data (copied by CI)
+  const candidates = [
+    path.join(process.cwd(), "..", "data"),
+    path.join(process.cwd(), "public", "data"),
+  ];
 
-  const files = fs.readdirSync(dataDir).filter((f) => f.endsWith(".json"));
-  const indicators: IndicatorData[] = [];
+  for (const dataDir of candidates) {
+    if (!fs.existsSync(dataDir)) continue;
 
-  for (const file of files) {
-    try {
-      const raw = fs.readFileSync(path.join(dataDir, file), "utf-8");
-      indicators.push(JSON.parse(raw));
-    } catch {
-      continue;
+    const files = fs.readdirSync(dataDir).filter((f) => f.endsWith(".json"));
+    if (files.length === 0) continue;
+
+    const indicators: IndicatorData[] = [];
+    for (const file of files) {
+      try {
+        const raw = fs.readFileSync(path.join(dataDir, file), "utf-8");
+        indicators.push(JSON.parse(raw));
+      } catch {
+        continue;
+      }
     }
+    if (indicators.length > 0) return indicators;
   }
 
-  return indicators;
+  return [];
 }
 
 export default function Home() {


### PR DESCRIPTION
- Copy data/*.json to site/public/data/ before build in deploy workflow
- Try multiple data paths (../data and public/data) for robustness
- Fixes "No data available yet" on deployed GitHub Pages site

https://claude.ai/code/session_01HypAghyn9xdnUveYcG1cKS