### PR TITLE
feat: enable Claude server management via SSH

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,8 +30,19 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup SSH for server management
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq openssh-client
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H sspprriinngg.cn >> ~/.ssh/known_hosts 2>/dev/null
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: sspprriinngg.cn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,44 @@ cd site && npm run build
 | `cleanup-preview.yml` | PR 关闭后清理预览 |
 | `update-data.yml` | 每小时抓取数据 |
 
+## Server Management
+
+Claude 在 GitHub Actions 中运行时，拥有对生产服务器的 SSH 访问权限，可以直接管理服务器。
+
+### SSH 连接方式
+
+```bash
+ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} "<command>"
+```
+
+环境变量 `DEPLOY_USER` 和 `DEPLOY_HOST` 已在 workflow 中设置。
+
+### 服务器信息
+
+- 主机：`sspprriinngg.cn`
+- 操作系统：CentOS（nginx/1.14.1）
+- Web 服务器：nginx
+- 站点根目录：`/var/www/html/`
+- Metric 站点目录：`/var/www/html/metric/`
+- Nginx 配置目录：`/etc/nginx/` （主配置 `/etc/nginx/nginx.conf`，站点配置 `/etc/nginx/conf.d/`）
+
+### 常见运维操作
+
+| 操作 | 命令 |
+|------|------|
+| 查看 nginx 配置 | `nginx -T` |
+| 测试 nginx 配置 | `nginx -t` |
+| 重载 nginx | `nginx -s reload` |
+| 查看站点文件 | `ls -la /var/www/html/metric/` |
+| 查看 nginx 错误日志 | `tail -50 /var/log/nginx/error.log` |
+| 查看 nginx 访问日志 | `tail -50 /var/log/nginx/access.log` |
+
+### 注意事项
+
+- 修改 nginx 配置前，务必先用 `nginx -t` 验证
+- 操作前先检查当前状态，避免覆盖已有配置
+- 对于破坏性操作（如删除文件、修改系统配置），应在 Issue/PR 中说明原因
+
 ## Conventions
 
 - 前端使用 TypeScript，暗色主题


### PR DESCRIPTION
## Summary
- Add SSH setup step in `claude.yml` so Claude Code Action can SSH into the production server
- Add Server Management section to `CLAUDE.md` with connection details and common operations
- This enables Claude to directly manage nginx config, debug deployments, and perform server operations when triggered via issues

## Test plan
- [ ] Merge this PR
- [ ] Create an issue with `@claude` asking to fix the nginx 404
- [ ] Verify Claude can SSH into the server and configure nginx

https://claude.ai/code/session_01HypAghyn9xdnUveYcG1cKS