### PR TITLE
fix: pin claude-code-action to working version

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Setup SSH for server management
         run: |
-          sudo apt-get update -qq && sudo apt-get install -y -qq openssh-client
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
@@ -40,7 +39,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.51
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         env:


### PR DESCRIPTION
## Summary
- Pin `claude-code-action` from `@v1` to `@v1.0.51` to avoid the known AJV schema validation crash (upstream issues #892, #947)
- Remove unnecessary `apt-get install openssh-client` (already on ubuntu-latest)

## Context
The `@v1` tag points to a version with a known SDK execution error that crashes before any API calls are made. Pinning to `v1.0.51` resolves this.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger issue #12 by commenting `@claude`
- [ ] Verify Claude Code Action runs successfully and can SSH into the server

https://claude.ai/code/session_01HypAghyn9xdnUveYcG1cKS