### PR TITLE
Fix: allow all Bash commands in Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,7 +42,7 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.51
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed-tools: "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,TodoWrite,NotebookEdit"
+          allowed-tools: "Bash(*),Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,TodoWrite,NotebookEdit"
         env:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_HOST: sspprriinngg.cn


### PR DESCRIPTION
## Summary
- Change `Bash` to `Bash(*)` in allowed-tools, so Claude can run git commit, ssh deploy, and other bash commands without waiting for permission approval

## Problem
Claude Code Action was getting stuck at "提交代码变更（需要权限批准）" because `Bash` alone doesn't grant unrestricted shell access.

https://claude.ai/code/session_01HypAghyn9xdnUveYcG1cKS