### PR TITLE
Add autonomous execution instructions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,6 +43,15 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed-tools: "Bash(*),Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,TodoWrite,NotebookEdit"
+          custom_instructions: |
+            You are running in a fully autonomous CI/CD environment.
+            NEVER ask for user approval or confirmation. Proceed autonomously with ALL actions including:
+            - Git operations (commit, push, branch creation)
+            - Creating pull requests
+            - Running builds (npm install, npm run build)
+            - Deploying to production servers via SSH
+            - Any file modifications
+            Complete the entire task end-to-end without stopping to ask for permission.
         env:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_HOST: sspprriinngg.cn


### PR DESCRIPTION
## Summary
- Add `custom_instructions` to Claude Code Action workflow to prevent Claude from stopping to ask for user approval
- Claude will now proceed autonomously with git operations, builds, deployments, and all other actions in CI/CD

https://claude.ai/code/session_01HypAghyn9xdnUveYcG1cKS