### PR TITLE
Separate Claude role from build/deploy

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,13 +30,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup SSH for server management
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H sspprriinngg.cn >> ~/.ssh/known_hosts 2>/dev/null
-
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1.0.51
@@ -48,10 +41,11 @@ jobs:
             NEVER ask for user approval or confirmation. Proceed autonomously with ALL actions including:
             - Git operations (commit, push, branch creation)
             - Creating pull requests
-            - Running builds (npm install, npm run build)
-            - Deploying to production servers via SSH
             - Any file modifications
             Complete the entire task end-to-end without stopping to ask for permission.
-        env:
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-          DEPLOY_HOST: sspprriinngg.cn
+
+            IMPORTANT: Do NOT build or deploy the project yourself.
+            - Do NOT run npm install, npm run build, or any build commands.
+            - Do NOT SSH into any server or run any deployment commands.
+            - Build and deploy are handled automatically by preview.yml (on PR) and deploy.yml (on merge to main).
+            - Your job is ONLY: write code, commit, push, and create a PR. That's it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,48 +50,26 @@ cd site && npm run build
 | Workflow | 作用 |
 |----------|------|
 | `claude.yml` | Issue/PR 中 @claude 触发自动开发 |
-| `preview.yml` | PR 预览部署 |
-| `deploy.yml` | 正式部署到服务器 |
+| `preview.yml` | PR 预览部署（自动触发，Claude 不需要干预） |
+| `deploy.yml` | 正式部署到服务器（合并到 main 后自动触发，Claude 不需要干预） |
 | `cleanup-preview.yml` | PR 关闭后清理预览 |
 | `update-data.yml` | 每小时抓取数据 |
 
-## Server Management
+### Claude 的职责边界
 
-Claude 在 GitHub Actions 中运行时，拥有对生产服务器的 SSH 访问权限，可以直接管理服务器。
+**Claude 只负责：**
+- 阅读和理解代码
+- 编写/修改代码
+- 提交代码（git commit + push）
+- 创建 Pull Request
 
-### SSH 连接方式
+**Claude 不要做（由 workflow 自动完成）：**
+- 不要运行 `npm install` / `npm run build` 构建项目
+- 不要 SSH 到服务器
+- 不要执行部署操作
+- 不要提供预览链接（preview.yml 会自动评论）
 
-```bash
-ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} "<command>"
-```
-
-环境变量 `DEPLOY_USER` 和 `DEPLOY_HOST` 已在 workflow 中设置。
-
-### 服务器信息
-
-- 主机：`sspprriinngg.cn`
-- 操作系统：CentOS（nginx/1.14.1）
-- Web 服务器：nginx
-- 站点根目录：`/var/www/html/`
-- Metric 站点目录：`/var/www/html/metric/`
-- Nginx 配置目录：`/etc/nginx/` （主配置 `/etc/nginx/nginx.conf`，站点配置 `/etc/nginx/conf.d/`）
-
-### 常见运维操作
-
-| 操作 | 命令 |
-|------|------|
-| 查看 nginx 配置 | `nginx -T` |
-| 测试 nginx 配置 | `nginx -t` |
-| 重载 nginx | `nginx -s reload` |
-| 查看站点文件 | `ls -la /var/www/html/metric/` |
-| 查看 nginx 错误日志 | `tail -50 /var/log/nginx/error.log` |
-| 查看 nginx 访问日志 | `tail -50 /var/log/nginx/access.log` |
-
-### 注意事项
-
-- 修改 nginx 配置前，务必先用 `nginx -t` 验证
-- 操作前先检查当前状态，避免覆盖已有配置
-- 对于破坏性操作（如删除文件、修改系统配置），应在 Issue/PR 中说明原因
+构建和部署完全由 `preview.yml` 和 `deploy.yml` 自动处理，Claude 提交 PR 后等待即可。
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
- Remove SSH setup from `claude.yml` — Claude 不再有服务器访问权限
- Update `custom_instructions` 明确禁止 Claude 执行构建和部署
- 重写 CLAUDE.md 的职责边界，删除 Server Management 整节
- Claude 只负责：写代码 → 提交 → 创建 PR，构建和部署交给 `preview.yml` / `deploy.yml`

## 改动前后对比

| | 之前 | 之后 |
|---|---|---|
| Claude 构建项目 | 会自己 `npm install && npm run build` | 不做，交给 workflow |
| Claude 部署 | 会 SSH 到服务器 rsync | 不做，交给 workflow |
| Claude 提供预览链接 | 自己拼链接 | 不做，`preview.yml` 自动评论 |

## Test plan
- [ ] 创建一个 Issue @claude，验证 Claude 只写代码+提PR，不做构建部署
- [ ] 验证 PR 创建后 `preview.yml` 自动触发部署预览

https://claude.ai/code/session_01HypAghyn9xdnUveYcG1cKS