### PR TITLE
Fix Claude CI: add Node.js setup and verification

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,13 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
       - name: Setup SSH for server management
         run: |
           mkdir -p ~/.ssh
@@ -49,9 +56,24 @@ jobs:
             - Git operations (commit, push, branch creation)
             - Creating pull requests
             - Running builds (npm install, npm run build)
-            - Deploying to production servers via SSH
+            - Deploying to servers via SSH
             - Any file modifications
             Complete the entire task end-to-end without stopping to ask for permission.
+
+            IMPORTANT - Verification before reporting:
+            - After building, verify that `site/out/` directory exists and contains index.html.
+            - After deploying via rsync, use `curl -s -o /dev/null -w "%{http_code}" <URL>` to verify the URL returns 200.
+            - NEVER mark a task as complete if the command failed or returned an error.
+            - If any step fails, report the ACTUAL error in your response instead of marking it as done.
+
+            Test deployment workflow:
+            1. Build: cd site && npm ci && NEXT_PUBLIC_BASE_PATH=/metric/test npm run build
+            2. Deploy: rsync site/out/ to /var/www/html/metric/test/ on the server
+            3. Verify: curl the test URL and confirm it returns 200
+            4. Report the test URL to the user: https://sspprriinngg.cn/metric/test/
+
+            Production deployment should NOT be done by Claude. Only test deployments.
+            Production is handled by deploy.yml after PR merge.
         env:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_HOST: sspprriinngg.cn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,39 @@ ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOS
 - 操作前先检查当前状态，避免覆盖已有配置
 - 对于破坏性操作（如删除文件、修改系统配置），应在 Issue/PR 中说明原因
 
+## 测试部署流程
+
+当需要部署到测试目录让用户预览时，按以下步骤执行：
+
+```bash
+# 1. 准备数据
+mkdir -p site/public/data && cp data/*.json site/public/data/
+
+# 2. 构建（使用测试 basePath）
+cd site && npm ci && NEXT_PUBLIC_BASE_PATH=/metric/test npm run build
+
+# 3. 验证构建产物存在
+ls site/out/index.html
+
+# 4. 部署到测试目录
+ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} "mkdir -p /var/www/html/metric/test/"
+rsync -avz --delete -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" site/out/ ${DEPLOY_USER}@${DEPLOY_HOST}:/var/www/html/metric/test/
+
+# 5. 验证部署成功（必须返回 200）
+curl -s -o /dev/null -w "%{http_code}" https://sspprriinngg.cn/metric/test/
+```
+
+**重要：每一步都必须检查返回值，任何一步失败都要如实报告错误，不能标记为完成。**
+
+测试地址：`https://sspprriinngg.cn/metric/test/`
+
+## 验证规则（必须遵守）
+
+- 构建后必须确认 `site/out/index.html` 存在
+- 部署后必须用 `curl` 验证 URL 返回 HTTP 200
+- 如果任何命令失败或返回错误码，**禁止**在任务清单中标记为 ✅
+- 如实报告错误信息，让用户知道哪一步出了问题
+
 ## Conventions
 
 - 前端使用 TypeScript，暗色主题


### PR DESCRIPTION
## Summary

Issue #17 失败的根本原因：

1. **`claude.yml` 没有 `setup-node` 步骤** — Claude 在 Actions 里运行 `npm ci` / `npm run build` 时没有正确的 Node.js 环境
2. **Claude 没有验证就标了 ✅** — 命令可能失败了，但 Claude 仍然在任务清单里标记为完成

## 改动

### claude.yml
- 新增 `setup-node@v4` 步骤，Node 20 + npm cache
- `custom_instructions` 新增验证要求：
  - 构建后必须确认 `site/out/index.html` 存在
  - 部署后必须 `curl` 验证返回 HTTP 200
  - 命令失败时禁止标记为完成，必须报告实际错误
- 明确测试部署流程（build → rsync → curl verify）
- 禁止 Claude 做生产部署，只做测试部署

### CLAUDE.md
- 新增「测试部署流程」章节，包含完整的 5 步命令
- 新增「验证规则」章节，强调必须验证、如实报告

## Test plan
- [ ] 在 Issue #17 重新 @claude，验证 Claude 能成功构建和部署到测试目录
- [ ] 验证 Claude 的回复中包含实际验证结果（HTTP 状态码）

https://claude.ai/code/session_01HypAghyn9xdnUveYcG1cKS