### PR TITLE
Fix: SSH setup should not block Claude Code step

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,11 +38,12 @@ jobs:
           cache-dependency-path: site/package-lock.json
 
       - name: Setup SSH for server management
+        continue-on-error: true
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H sspprriinngg.cn >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -H sspprriinngg.cn >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary

上次触发 Claude Action 时，`Setup SSH` 步骤失败（可能是 ssh-keyscan 超时），导致后续的 `Run Claude Code` 步骤被直接跳过，Claude 完全没运行。

### 修复
- 给 SSH setup 步骤加了 `continue-on-error: true`
- ssh-keyscan 命令加了 `|| true`

这样即使 SSH 设置失败，Claude 仍然可以运行（只是不能 SSH 部署）。

https://claude.ai/code/session_01HypAghyn9xdnUveYcG1cKS